### PR TITLE
Increase SessionStore.monitor genserver timeout

### DIFF
--- a/lib/wallaby/session_store.ex
+++ b/lib/wallaby/session_store.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.SessionStore do
 
   def start_link, do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
 
-  def monitor(session), do: GenServer.call(__MODULE__, {:monitor, session})
+  def monitor(session), do: GenServer.call(__MODULE__, {:monitor, session}, 10_000)
 
   def demonitor(session), do: GenServer.call(__MODULE__, {:demonitor, session})
 


### PR DESCRIPTION
(for better browserstack handling)

When running tests on Browserstack on Chrome on Windows 10, the first test passes,
but when a second test starts, we get an error in Wallaby:

    ** (exit) exited in: GenServer.call(Wallaby.SessionStore, {:monitor, %Wallaby.Session{driver: Wallaby.Experimental.Selenium, id: "session_id", screenshots: [], server: :none, session_url: "http://login:password@hub.browserstack.com:80/wd/hub/session/session_id", url: "http://login:password@hub.browserstack.com:80/wd/hub/session/session_id"}}, 5000)
        ** (EXIT) time out

Increasing this timeout to 10s seems to resolve this particular issue.