### PR TITLE
Added handling of JS alert/confirm/prompt for Selenium

### DIFF
--- a/integration_test/cases/browser/dialog_test.exs
+++ b/integration_test/cases/browser/dialog_test.exs
@@ -50,9 +50,9 @@ defmodule Wallaby.Integration.Browser.DialogTest do
 
   describe "accept_prompt/2" do
     test "accept window.prompt with default value and get message", %{page: page} do
-      message = accept_prompt page, fn(p) ->
+      message = accept_prompt(page, fn(p) ->
         click(p, Query.link("Prompt"))
-      end
+      end)
       result =
         page
         |> find(Query.css("#result"))
@@ -92,9 +92,9 @@ defmodule Wallaby.Integration.Browser.DialogTest do
 
   describe "dismiss_prompt/2" do
     test "dismiss window.prompt and get message", %{page: page} do
-      message = dismiss_prompt page, fn(p) ->
+      message = dismiss_prompt(page, fn(p) ->
         click(p, Query.link("Prompt"))
-      end
+      end)
 
       result =
         page

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -77,13 +77,12 @@ defmodule Wallaby.Experimental.Selenium do
     end
   end
 
-  # Dialog handling not supported yet
-  def accept_alert(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_alert(_session, _fun), do: {:error, :not_implemented}
-  def accept_confirm(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_confirm(_session, _fun), do: {:error, :not_implemented}
-  def accept_prompt(_session, _input, _fun), do: {:error, :not_implemented}
-  def dismiss_prompt(_session, _fun), do: {:error, :not_implemented}
+  defdelegate accept_alert(session, fun), to: WebdriverClient
+  defdelegate dismiss_alert(session, fun), to: WebdriverClient
+  defdelegate accept_confirm(session, fun), to: WebdriverClient
+  defdelegate dismiss_confirm(session, fun), to: WebdriverClient
+  defdelegate accept_prompt(session, input, fun), to: WebdriverClient
+  defdelegate dismiss_prompt(session, fun), to: WebdriverClient
 
   # Screenshots don't appear to be supported with Gecko Driver
   def take_screenshot(_session), do: {:error, :not_supported}

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -363,6 +363,9 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   defp cast_as_element(parent, %{"ELEMENT" => id}) do
     cast_as_element(parent, %{@web_element_identifier => id})
   end
+  defp cast_as_element(parent, {_, _}) do
+    cast_as_element(parent, %{@web_element_identifier => parent.id})
+  end
   defp cast_as_element(parent, %{@web_element_identifier => id}) do
     %Wallaby.Element{
       id: id,


### PR DESCRIPTION
JS `window.alert`, `window.confirm` and `window.prompt` were handled by chromedriver and phantomjs, but for selenium functions for accept and dismiss them were not implemented.

This PR adds code that allows to use the following functions:

- `accept_alert/2`,
- `accept_confirm/2`,
- `accept_prompt/2`,
- `accept_prompt/3`,
- `dismiss_confirm/2`
- `dismiss_prompt/2`,
- `dismiss_alert/2` (it is the same as `accept_alert/2` in fact).