### PR TITLE
JS alert, confirm, and prompt for Selenium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.4.5
-  - 1.5.3
-  - 1.6.4
+  - 1.6.6
+  - 1.7.4
+  - 1.8.1
 otp_release:
   - 20.3
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-## 0.22.0 (pending)
+## 0.23.0 (pending)
+
+## 0.22.0 (2019-02-26)
+
+## Improvements
+
+* Add `Query.data` to find by data attributes
+* Add selected conditions to query
+* Add functions for query options
+* Add `visible: any` option to query
+* Handle Safari and Edge stale reference errors
+
+## Bugfixes
+
+* allow newlines in chrome logs
+* Allow other versions of chromedriver
+* Increase the session store genserver timeout
 
 ## 0.21.0 (2018-11-19)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Add Wallaby to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:wallaby, "~> 0.20.0", [runtime: false, only: :test]}]
+  [{:wallaby, "~> 0.22.0", [runtime: false, only: :test]}]
 end
 ```
 

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -1,7 +1,6 @@
 Code.require_file "../tests.exs", __DIR__
 
 # Additional test cases supported by phantom
-Code.require_file "../cases/browser/dialog_test.exs", __DIR__
 Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
 Code.require_file "../cases/browser/screenshot_test.exs", __DIR__

--- a/integration_test/phantom/all_test.exs
+++ b/integration_test/phantom/all_test.exs
@@ -1,7 +1,6 @@
 Code.require_file "../tests.exs", __DIR__
 
 # Additional test cases supported by phantom
-Code.require_file "../cases/browser/dialog_test.exs", __DIR__
 Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
 Code.require_file "../cases/browser/screenshot_test.exs", __DIR__

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -10,6 +10,7 @@ Code.require_file "cases/browser/click_button_test.exs", __DIR__
 Code.require_file "cases/browser/click_test.exs", __DIR__
 Code.require_file "cases/browser/cookies_test.exs", __DIR__
 Code.require_file "cases/browser/current_path_test.exs", __DIR__
+Code.require_file "cases/browser/dialog_test.exs", __DIR__
 Code.require_file "cases/browser/execute_script_test.exs", __DIR__
 Code.require_file "cases/browser/fill_in_test.exs", __DIR__
 Code.require_file "cases/browser/find_test.exs", __DIR__

--- a/lib/wallaby/driver/process_workspace/server.ex
+++ b/lib/wallaby/driver/process_workspace/server.ex
@@ -22,11 +22,11 @@ defmodule Wallaby.Driver.ProcessWorkspace.Server do
     File.rm_rf(workspace_path)
     {:stop, :normal, state}
   end
-  def handle_info(msg, state), do: super(msg, state)
+  def handle_info(_, state), do: {:noreply, state}
 
   @impl GenServer
   def terminate(:shutdown, %{workspace_path: workspace_path}) do
     File.rm_rf(workspace_path)
   end
-  def terminate(reason, state), do: super(reason, state)
+  def terminate(_, _), do: :ok
 end

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -77,13 +77,12 @@ defmodule Wallaby.Experimental.Selenium do
     end
   end
 
-  # Dialog handling not supported yet
-  def accept_alert(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_alert(_session, _fun), do: {:error, :not_implemented}
-  def accept_confirm(_session, _fun), do: {:error, :not_implemented}
-  def dismiss_confirm(_session, _fun), do: {:error, :not_implemented}
-  def accept_prompt(_session, _input, _fun), do: {:error, :not_implemented}
-  def dismiss_prompt(_session, _fun), do: {:error, :not_implemented}
+  defdelegate accept_alert(session, fun), to: WebdriverClient
+  defdelegate dismiss_alert(session, fun), to: WebdriverClient
+  defdelegate accept_confirm(session, fun), to: WebdriverClient
+  defdelegate dismiss_confirm(session, fun), to: WebdriverClient
+  defdelegate accept_prompt(session, input, fun), to: WebdriverClient
+  defdelegate dismiss_prompt(session, fun), to: WebdriverClient
 
   # Screenshots don't appear to be supported with Gecko Driver
   def take_screenshot(_session), do: {:error, :not_supported}

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -105,10 +105,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   end
 
   def dismiss_prompt(session, fun) do
-    fun.(session)
-    with  {:ok, value} <- alert_text(session),
-          {:ok, _resp} <- request(:post, "#{session.url}/alert/dismiss"),
-      do: value
+    dismiss_confirm(session, fun)
   end
 
   @doc """

--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -77,11 +77,16 @@ defmodule Wallaby.HTTPClient do
     end
   end
 
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp check_for_response_errors(response) do
     case Map.get(response, "value") do
       %{"class" => "org.openqa.selenium.StaleElementReferenceException"} ->
         {:error, :stale_reference}
+      %{"message" => "Stale element reference" <> _} ->
+        {:error, :stale_reference}
       %{"message" => "stale element reference" <> _} ->
+        {:error, :stale_reference}
+      %{"message" => "An element command failed because the referenced element is no longer available" <> _} ->
         {:error, :stale_reference}
       %{"message" => "invalid selector" <> _} ->
         {:error, :invalid_selector}

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -85,7 +85,7 @@ defmodule Wallaby.Phantom.Server do
   def handle_info({port, {:exit_status, status}}, %ServerState{wrapper_script_port: port} = state) do
     {:stop, {:exit_status, status}, state}
   end
-  def handle_info(msg, state), do: super(msg, state)
+  def handle_info(_, state), do: {:noreply, state}
 
   @impl GenServer
   def terminate(_reason, %ServerState{wrapper_script_port: wrapper_script_port, wrapper_script_os_pid: wrapper_script_os_pid}) do

--- a/lib/wallaby/session_store.ex
+++ b/lib/wallaby/session_store.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.SessionStore do
 
   def start_link, do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
 
-  def monitor(session), do: GenServer.call(__MODULE__, {:monitor, session})
+  def monitor(session), do: GenServer.call(__MODULE__, {:monitor, session}, 10_000)
 
   def demonitor(session), do: GenServer.call(__MODULE__, {:demonitor, session})
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Wallaby.Mixfile do
   use Mix.Project
 
-  @version "0.21.0"
+  @version "0.22.0"
   @drivers ~w(phantom selenium chrome)
   @selected_driver System.get_env("WALLABY_DRIVER")
   @maintainers [


### PR DESCRIPTION
JS `window.alert`, `window.confirm` and `window.prompt` were handled by Chromedriver and PhantomJS, but for selenium functions for accept and dismiss them were not implemented.

This PR adds code that allows to use the following functions:

- `accept_alert/2`,
- `accept_confirm/2`,
- `accept_prompt/2`,
- `accept_prompt/3`,
- `dismiss_confirm/2`
- `dismiss_prompt/2`,
- `dismiss_alert/2`.

Also changed implementation of `dismiss_prompt/2` (switched to use `dismiss_confirm/2`) and moved `integration_test/cases/browser/dialog_test.exs` to the set of default tests for all drivers.