### PR TITLE
 update master from Wallaby upstream

### DIFF
--- a/integration_test/cases/browser/window_handles_test.exs
+++ b/integration_test/cases/browser/window_handles_test.exs
@@ -1,0 +1,71 @@
+defmodule Wallaby.Integration.Browser.WindowHandlesTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  test "switching between tabs and windows", %{session: session} do
+    session
+    |> visit("windows.html")
+
+    initial_handle = window_handle(session)
+    assert [initial_handle] == window_handles(session)
+
+    session
+    |> click(Query.link("New tab"))
+    :timer.sleep(500)
+
+    handles = window_handles(session)
+    assert length(handles) == 2
+
+    new_tab_handle = Enum.find(handles, fn handle -> handle != initial_handle end)
+    focus_window(session, new_tab_handle)
+
+    assert new_tab_handle == window_handle(session)
+    assert_has(session, Query.css("h1", text: "Page 1"))
+
+    session
+    |> focus_window(initial_handle)
+    |> click(Query.link("New window"))
+    :timer.sleep(500)
+
+    handles2 = window_handles(session)
+    assert length(handles2) == 3
+
+    new_window_handle = Enum.find(handles2, fn handle -> handle not in [initial_handle, new_tab_handle] end)
+    focus_window(session, new_window_handle)
+
+    assert new_window_handle == window_handle(session)
+    assert_has(session, Query.css("h1", text: "Page 2"))
+  end
+
+  test "closing tabs and windows", %{session: session} do
+    session
+    |> visit("windows.html")
+
+    initial_handle = window_handle(session)
+
+    session
+    |> click(Query.link("New tab"))
+    :timer.sleep(500)
+
+    new_tab_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
+
+    session
+    |> focus_window(new_tab_handle)
+    |> close_window()
+    |> focus_window(initial_handle)
+
+    assert [initial_handle] == window_handles(session)
+
+    session
+    |> click(Query.link("New window"))
+    :timer.sleep(500)
+
+    new_window_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
+
+    session
+    |> focus_window(new_window_handle)
+    |> close_window()
+    |> focus_window(initial_handle)
+
+    assert [initial_handle] == window_handles(session)
+  end
+end

--- a/integration_test/cases/browser/window_position_test.exs
+++ b/integration_test/cases/browser/window_position_test.exs
@@ -1,0 +1,13 @@
+defmodule Wallaby.Integration.Browser.WindowPositionTest do
+  use Wallaby.Integration.SessionCase, async: true
+
+  test "getting the window position", %{session: session} do
+    window_position =
+      session
+      |> visit("/")
+      |> move_window(100, 200)
+      |> window_position()
+
+    assert %{"x" => 100, "y" => 200} = window_position
+  end
+end

--- a/integration_test/cases/browser/window_size_test.exs
+++ b/integration_test/cases/browser/window_size_test.exs
@@ -13,13 +13,12 @@ defmodule Wallaby.Integration.Browser.WindowSizeTest do
 
   describe "default window size" do
     setup do
-      inject_test_session(%{skip_test_session: true})
-
       {:ok, session} = start_test_session(window_size: [width: 600, height: 400])
 
       {:ok, %{session: session}}
     end
 
+    @tag :skip_test_session
     test "sets window size from config option", %{session: session} do
       window_size =
         session

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -5,3 +5,5 @@ Code.require_file "../cases/browser/file_test.exs", __DIR__
 Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
 Code.require_file "../cases/browser/hover_test.exs", __DIR__
 Code.require_file "../cases/element/hover_test.exs", __DIR__
+Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
+Code.require_file "../cases/browser/window_position_test.exs", __DIR__

--- a/integration_test/selenium/all_test.exs
+++ b/integration_test/selenium/all_test.exs
@@ -3,3 +3,5 @@ Code.require_file "../tests.exs", __DIR__
 # Additional test cases supported by selenium
 Code.require_file "../cases/browser/hover_test.exs", __DIR__
 Code.require_file "../cases/element/hover_test.exs", __DIR__
+Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
+Code.require_file "../cases/browser/window_position_test.exs", __DIR__

--- a/integration_test/support/pages/windows.html
+++ b/integration_test/support/pages/windows.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<head>
+  <title>Windows</title>
+</head>
+
+<body>
+  <a href="page_1.html" rel="noopener noreferrer" target="_blank">New tab or window link</a>
+  <a href="page_2.html" onclick="window.open('page_2.html', 'newwindow', 'width=600,height=400'); return false;">New
+    window link</a>
+</body>
+
+</html>

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -171,7 +171,7 @@ defmodule Wallaby.Browser do
       |> fill_in(Query.css("#password_field", with: "secret42"))
 
   ### Note
-  
+
   Currently, ChromeDriver only supports [BMP Unicode](http://www.unicode.org/roadmaps/bmp/) characters. Emojis are [SMP](https://www.unicode.org/roadmaps/smp/) characters and will be ignored by ChromeDriver.
 
   Using JavaScript is a known workaround for filling in fields with Emojis and other non-BMP characters.
@@ -232,22 +232,94 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Gets the size of the session's window.
+  Gets the window handle of the currently focused window.
+  """
+  @spec window_handle(parent) :: String.t
+
+  def window_handle(%{driver: driver} = session) do
+    {:ok, handle} = driver.window_handle(session)
+    handle
+  end
+
+  @doc """
+  Gets the window handles of all available windows.
+  """
+  @spec window_handles(parent) :: [String.t]
+
+  def window_handles(%{driver: driver} = session) do
+    {:ok, handles} = driver.window_handles(session)
+    handles
+  end
+
+  @doc """
+  Changes the driver focus to the window identified by the handle.
+  """
+  @spec focus_window(parent, String.t) :: parent
+
+  def focus_window(%{driver: driver} = session, window_handle) do
+    {:ok, _} = driver.focus_window(session, window_handle)
+    session
+  end
+
+  @doc """
+  Closes the currently focused window.
+  """
+  @spec close_window(parent) :: parent
+
+  def close_window(%{driver: driver} = session) do
+    {:ok, _} = driver.close_window(session)
+    session
+  end
+
+  @doc """
+  Gets the size of the currently focused window.
   """
   @spec window_size(parent) :: %{String.t => pos_integer, String.t => pos_integer}
 
-  def window_size(%Session{driver: driver} = session) do
+  def window_size(%{driver: driver} = session) do
     {:ok, size} = driver.get_window_size(session)
     size
   end
 
   @doc """
-  Sets the size of the sessions window.
+  Sets the size of the currenty focused window.
   """
   @spec resize_window(parent, pos_integer, pos_integer) :: parent
 
-  def resize_window(%Session{driver: driver} = session, width, height) do
+  def resize_window(%{driver: driver} = session, width, height) do
     {:ok, _} = driver.set_window_size(session, width, height)
+    session
+  end
+
+  @doc """
+  Maximizes the currenty focused window.
+
+  For most browsers, this requires a window manager to be running.
+  """
+  @spec maximize_window(parent) :: parent
+
+  def maximize_window(%{driver: driver} = session) do
+    {:ok, _} = driver.maximize_window(session)
+    session
+  end
+
+  @doc """
+  Gets the position of the currently focused window.
+  """
+  @spec window_position(parent) :: %{String.t => pos_integer, String.t => pos_integer}
+
+  def window_position(%{driver: driver} = session) do
+    {:ok, position} = driver.get_window_position(session)
+    position
+  end
+
+  @doc """
+  Sets the position of the currenty focused window.
+  """
+  @spec move_window(parent, pos_integer, pos_integer) :: parent
+
+  def move_window(%{driver: driver} = session, x, y) do
+    {:ok, _} = driver.set_window_position(session, x, y)
     session
   end
 
@@ -323,7 +395,7 @@ defmodule Wallaby.Browser do
       iex> Wallaby.Session.send_keys(session, [:shift, :enter])
 
   ### Note
-  
+
   Currently, ChromeDriver only supports [BMP Unicode](http://www.unicode.org/roadmaps/bmp/) characters. Emojis are [SMP](https://www.unicode.org/roadmaps/smp/) characters and will be ignored by ChromeDriver.
 
   Using JavaScript is a known workaround for filling in fields with Emojis and other non-BMP characters.

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -7,6 +7,7 @@ defmodule Wallaby.Driver do
   @type url :: String.t
   @type open_dialog_fn :: ((Session.t) -> any)
   @type window_dimension :: %{String.t => pos_integer, String.t => pos_integer}
+  @type window_position :: %{String.t => pos_integer, String.t => pos_integer}
 
   @type on_start_session :: {:ok, Session.t} | {:error, reason}
 
@@ -37,6 +38,11 @@ defmodule Wallaby.Driver do
     {:ok, [String.t]} | {:error, reason}
 
   @doc """
+  Invoked to close the currently focused window.
+  """
+  @callback close_window(Session.t | Element.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
   Invoked to retrieve cookies for the given session.
   """
   @callback cookies(Session.t) :: {:ok, [%{String.t => String.t}]} | {:error, reason}
@@ -62,9 +68,24 @@ defmodule Wallaby.Driver do
   @callback dismiss_prompt(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
 
   @doc """
-  Invoked to retrieve the size of the window.
+  Invoked to change the driver focus to window specified by handle.
   """
-  @callback get_window_size(Session.t) :: {:ok, window_dimension} | {:error, reason}
+  @callback focus_window(Session.t | Element.t, String.t) :: {:ok, any} | {:error, reason}
+
+  @doc """
+  Invoked to retrieve the position of the currently focused window.
+  """
+  @callback get_window_position(Session.t | Element.t) :: {:ok, window_position} | {:error, reason}
+
+  @doc """
+  Invoked to retrieve the size of the currently focused window.
+  """
+  @callback get_window_size(Session.t | Element.t) :: {:ok, window_dimension} | {:error, reason}
+
+  @doc """
+  Invoked to maximize the currently focused window.
+  """
+  @callback maximize_window(Session.t | Element.t) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve the html source of the current page.
@@ -82,9 +103,16 @@ defmodule Wallaby.Driver do
   @callback set_cookie(Session.t, String.t, String.t) :: {:ok, any} | {:error, reason}
 
   @doc """
-  Invoked to set the size of the window.
+  Invoked to set the size of the currently focused window.
   """
-  @callback set_window_size(Session.t, pos_integer, pos_integer) :: {:ok, any} | {:error, reason}
+  @callback set_window_size(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} |
+    {:error, reason}
+
+  @doc """
+  Invoked to set the position of the currently focused window.
+  """
+  @callback set_window_position(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} |
+    {:error, reason}
 
   @doc """
   Invoked to visit a url.
@@ -149,4 +177,14 @@ defmodule Wallaby.Driver do
   Invoked to take a screenshot of the session/element.
   """
   @callback take_screenshot(Session.t | Element.t) :: binary | {:error, reason}
+
+  @doc """
+  Invoked to get the handle for the currently focused window.
+  """
+  @callback window_handle(Session.t | Element.t) :: {:ok, String.t} | {:error, reason}
+
+  @doc """
+  Invoked to get the list of handles for all windows.
+  """
+  @callback window_handles(Session.t | Element.t) :: {:ok, [String.t]} | {:error, reason}
 end

--- a/lib/wallaby/experimental/chrome.ex
+++ b/lib/wallaby/experimental/chrome.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Experimental.Chrome do
 
   @chromedriver_version_regex ~r/^ChromeDriver (\d+)\.(\d+)/
 
-  alias Wallaby.{Session, DependencyError, Metadata}
+  alias Wallaby.{DependencyError, Metadata}
   alias Wallaby.Experimental.Chrome.{Chromedriver}
   alias Wallaby.Experimental.Selenium.WebdriverClient
   import Wallaby.Driver.LogChecker
@@ -127,16 +127,6 @@ defmodule Wallaby.Experimental.Chrome do
     end
   end
 
-  def get_window_size(%Session{} = session) do
-    handle = delegate(:window_handle, session)
-    delegate(:get_window_size, session, [handle])
-  end
-
-  def set_window_size(session, width, height) do
-    handle = delegate(:window_handle, session)
-    delegate(:set_window_size, session, [handle, width, height])
-  end
-
   defp delegate(fun, element_or_session, args \\ []) do
     check_logs!(element_or_session, fn ->
       apply(WebdriverClient, fun, [element_or_session | args])
@@ -151,6 +141,25 @@ defmodule Wallaby.Experimental.Chrome do
   defdelegate dismiss_prompt(session, fun), to: WebdriverClient
   defdelegate parse_log(log), to: Wallaby.Experimental.Chrome.Logger
 
+  @doc false
+  def window_handle(session), do: delegate(:window_handle, session)
+  @doc false
+  def window_handles(session), do: delegate(:window_handles, session)
+  @doc false
+  def focus_window(session, window_handle), do: delegate(:focus_window, session, [window_handle])
+  @doc false
+  def close_window(session), do: delegate(:close_window, session)
+  @doc false
+  def get_window_size(session), do: delegate(:get_window_size, session)
+  @doc false
+  def set_window_size(session, width, height),
+    do: delegate(:set_window_size, session, [width, height])
+  @doc false
+  def get_window_position(session), do: delegate(:get_window_position, session)
+  @doc false
+  def set_window_position(session, x, y), do: delegate(:set_window_position, session, [x, y])
+  @doc false
+  def maximize_window(session), do: delegate(:maximize_window, session)
   @doc false
   def cookies(session), do: delegate(:cookies, session)
   @doc false

--- a/lib/wallaby/experimental/selenium.ex
+++ b/lib/wallaby/experimental/selenium.ex
@@ -77,6 +77,16 @@ defmodule Wallaby.Experimental.Selenium do
     end
   end
 
+  defdelegate window_handle(session), to: WebdriverClient
+  defdelegate window_handles(session), to: WebdriverClient
+  defdelegate focus_window(session, window_handle), to: WebdriverClient
+  defdelegate close_window(session), to: WebdriverClient
+  defdelegate get_window_size(session), to: WebdriverClient
+  defdelegate set_window_size(session, width, height), to: WebdriverClient
+  defdelegate get_window_position(session), to: WebdriverClient
+  defdelegate set_window_position(session, x, y), to: WebdriverClient
+  defdelegate maximize_window(session), to: WebdriverClient
+
   defdelegate accept_alert(session, fun), to: WebdriverClient
   defdelegate dismiss_alert(session, fun), to: WebdriverClient
   defdelegate accept_confirm(session, fun), to: WebdriverClient
@@ -101,11 +111,6 @@ defmodule Wallaby.Experimental.Selenium do
     WebdriverClient.current_url(session)
   end
 
-  def get_window_size(%Session{} = session) do
-    handle = WebdriverClient.window_handle(session)
-    WebdriverClient.get_window_size(session, handle)
-  end
-
   def page_source(%Session{} = session) do
     WebdriverClient.page_source(session)
   end
@@ -116,11 +121,6 @@ defmodule Wallaby.Experimental.Selenium do
 
   def set_cookie(%Session{} = session, key, value) do
     WebdriverClient.set_cookie(session, key, value)
-  end
-
-  def set_window_size(%Session{} = session, width, height) do
-    handle = WebdriverClient.window_handle(session)
-    WebdriverClient.set_window_size(session, handle, width, height)
   end
 
   def visit(%Session{} = session, path) do

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -208,4 +208,12 @@ defmodule Wallaby.Phantom do
   defp configured_phantom_js do
     Application.get_env(:wallaby, :phantomjs, "phantomjs")
   end
+
+  def window_handle(_session), do: {:error, :not_supported}
+  def window_handles(_session), do: {:error, :not_supported}
+  def focus_window(_session, _window_handle), do: {:error, :not_supported}
+  def close_window(_session), do: {:error, :not_supported}
+  def get_window_position(_session), do: {:error, :not_supported}
+  def set_window_position(_session, _x, _y), do: {:error, :not_supported}
+  def maximize_window(_session), do: {:error, :not_supported}
 end

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -584,13 +584,12 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
   describe "set_window_size/3" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
-      window_handle_id = "my-window-handle"
       height = 600
       width = 400
 
       handle_request bypass, fn conn ->
         assert conn.method == "POST"
-        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/size"
+        assert conn.request_path == "/session/#{session.id}/window/current/size"
         assert conn.body_params == %{"height" => height, "width" => width}
 
         send_resp(conn, 200, ~s<{
@@ -600,18 +599,17 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert {:ok, %{}} = Client.set_window_size(session, window_handle_id, width, height)
+      assert {:ok, %{}} = Client.set_window_size(session, width, height)
     end
   end
 
   describe "get_window_size/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
-      window_handle_id = "my-window-handle"
 
       handle_request bypass, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/session/#{session.id}/window/#{window_handle_id}/size"
+        assert conn.request_path == "/session/#{session.id}/window/current/size"
 
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
@@ -623,7 +621,70 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session, window_handle_id)
+      assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session)
+    end
+  end
+
+  describe "set_window_position/3" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      x_coordinate = 600
+      y_coordinate = 400
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/current/position"
+        assert conn.body_params == %{"x" => x_coordinate, "y" => y_coordinate}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.set_window_position(session, x_coordinate, y_coordinate)
+    end
+  end
+
+  describe "get_window_position/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window/current/position"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {
+            "x": 600,
+            "y": 400
+          }
+        }>)
+      end
+
+      assert {:ok, %{"x" => 600, "y" => 400}} == Client.get_window_position(session)
+    end
+  end
+
+  describe "maximize_window/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window/current/maximize"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} == Client.maximize_window(session)
     end
   end
 
@@ -730,6 +791,25 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     end
   end
 
+  describe "window_handles/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "GET"
+        assert conn.request_path == "/session/#{session.id}/window_handles"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": ["some-window-handle", "other-window-handle"]
+        }>)
+      end
+
+      assert {:ok, ["some-window-handle", "other-window-handle"]} = Client.window_handles(session)
+    end
+  end
+
   describe "window_handle/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
@@ -745,7 +825,47 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         }>)
       end
 
-      assert "my-window-handle" = Client.window_handle(session)
+      assert {:ok, "my-window-handle"} = Client.window_handle(session)
+    end
+  end
+
+  describe "focus_window/2" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+      window_handle_id = "my-window-handle"
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "POST"
+        assert conn.request_path == "/session/#{session.id}/window"
+        assert conn.body_params == %{"name" => window_handle_id, "handle" => window_handle_id}
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.focus_window(session, window_handle_id)
+    end
+  end
+
+  describe "close_window/1" do
+    test "sends the correct request to the server", %{bypass: bypass} do
+      session = build_session_for_bypass(bypass)
+
+      handle_request bypass, fn conn ->
+        assert conn.method == "DELETE"
+        assert conn.request_path == "/session/#{session.id}/window"
+
+        send_resp(conn, 200, ~s<{
+          "sessionId": "#{session.id}",
+          "status": 0,
+          "value": {}
+        }>)
+      end
+
+      assert {:ok, %{}} = Client.close_window(session)
     end
   end
 


### PR DESCRIPTION
* Add WebdriverClient.focus_window/2
* Add WebdriverClient.close_window/1
* Add WebdriverClient.set_window_position/3
* Add WebdriverClient.get_window_position/1
* Add WebdriverClient.maximize_window/1
* Use "current" in endpoint URL (following the old Selenium WebDriver protocol) in WebdriverClient.get_window_size/1 and WebDriverClient.set_window_size/3
* Make WebdriverClient return values more consistent
* Expose new commands through Browser module